### PR TITLE
chore: publicリポジトリにするための準備

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -4,5 +4,17 @@ on:
   push:
 
 jobs:
-  workflows-linter:
-    uses: sensyn-robotics/github-actions/.github/workflows/actionlint.yaml@main
+  Actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download actionlint
+        id: get_actionlint
+        shell: bash
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+
+      - name: Lint
+        shell: bash
+        run: ${{ steps.get_actionlint.outputs.executable }} -color -shellcheck=


### PR DESCRIPTION
## なぜpublicにしたいか
- publicリポジトリから、ここで管理しているcustom actionを利用したいため。

## やったこと
- このリポジトリ自身もprivate custom actionを使っているので、輸入してきた。